### PR TITLE
/profile

### DIFF
--- a/app/(main)/profile/page.tsx
+++ b/app/(main)/profile/page.tsx
@@ -1,16 +1,43 @@
 import ProfileEditModal from "@/components/profile-edit-modal";
+import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar";
+import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
+import { PostList } from "@/components/post"
 
 export default function Profile() {
   return (
-    <div>
+    <div className = "flex flex-col items-center mt-[36px]">
+      <Avatar className = "flex justify-center w-[128px] h-[128px]">
+        <AvatarImage
+          src="https://github.com/shadcn.png"
+          alt="プロフィール画像"
+          className="h-full w-auto aspect-square cursor-pointer"
+        />
+        <AvatarFallback>CN</AvatarFallback>
+      </Avatar>
+      <div className = "mt-[16px] flex flex-col items-center">
+        <p className = "text-[22px] text-[#171412]">アリサ コーピー</p>
+        <p className = "text-[16px] text-[#827066]">@alisacooper</p>
+      </div>
       <ProfileEditModal>
         <button
           type="button"
-          className="text-lg px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700"
+          className="mt-[16px] w-[240px] h-[40px] bg-[#f5f2f2] font-normal text-[14px] leading-[21px] tracking-normal text-center rounded-[20px] hover:bg-gray-200 cursor-pointer"
         >
           プロフィールを編集
         </button>
       </ProfileEditModal>
+      <Tabs defaultValue="self" className="w-[960px] mt-[16px]">
+        <TabsList>
+          <TabsTrigger value="self">投稿</TabsTrigger>
+          <TabsTrigger value="like">いいね</TabsTrigger>
+        </TabsList>
+        <TabsContent value="self">
+          <PostList isSelfPost={true} />
+        </TabsContent>
+        <TabsContent value="like">
+          <PostList isSelfPost={false} />
+        </TabsContent>
+      </Tabs>
     </div>
   );
 }

--- a/components/post.tsx
+++ b/components/post.tsx
@@ -1,0 +1,100 @@
+import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar";
+import { ThumbsUp } from "lucide-react";
+
+type PostType = {
+  id: number;
+  author: {
+    name: string;
+    username: string;
+    avatarUrl: string;
+  };
+  content: string;
+  likes: number;
+  date: Date;
+};
+
+const initialDate: Date = new Date("2025-07-20");
+const secondDate: Date = new Date("2025-07-22")
+
+// 自分の投稿のモックデータ
+const mockSelfPosts: PostType[] = [
+  {
+    id: 1,
+    author: {
+      name: "田中 太郎",
+      username: "tanaka_taro",
+      avatarUrl: "https://github.com/shadcn.png",
+    },
+    content: "今日のランチはラーメンでした！とても美味しかったです。 #ラーメン",
+    likes: 15,
+    date: initialDate,
+  },
+  {
+    id: 2,
+    author: {
+      name: "田中 太郎",
+      username: "tanaka_taro",
+      avatarUrl: "https://github.com/shadcn.png",
+    },
+    content: "今日いただいたわりに心から感謝しています。これは、たとえ小さな情のある行為でも大きな違いを生むことができることを思い出させます。もっと優しさを広げましょう！",
+    likes: 32,
+    date: secondDate,
+  },
+];
+
+
+
+// いいねした投稿のモックデータ
+const mockLikedPosts: PostType[] = [
+  {
+    id: 3,
+    author: {
+      name: "鈴木 一郎",
+      username: "suzuki_ichiro",
+      avatarUrl: "https://github.com/vercel.png",
+    },
+    content: "今日いただいたわりに心から感謝しています。これは、たとえ小さな情のある行為でも大きな違いを生むことができることを思い出させます。もっと優しさを広げましょう！",
+    likes: 128,
+    date: initialDate,
+  },
+];
+
+
+export const PostList = ({ isSelfPost }: { isSelfPost: boolean }) => {
+
+  const posts: PostType[] = isSelfPost ? mockSelfPosts : mockLikedPosts;
+
+  return (
+    <div>
+      {posts.map((post) => {
+        const today = new Date();
+        const startOfToday = new Date(today.getFullYear(), today.getMonth(), today.getDate());
+        const startOfTarget = new Date(post.date.getFullYear(), post.date.getMonth(), post.date.getDate());
+        const diffInMs = startOfToday.getTime() - startOfTarget.getTime();
+        const daysAgo = Math.floor(diffInMs / (1000 * 60 * 60 * 24));
+
+        return (
+          <div key={post.id} className="flex px-[16px] py-[12px]">
+            <Avatar>
+              <AvatarImage src={post.author.avatarUrl} />
+              <AvatarFallback>
+                {post.author.name.slice(0, 2)}
+              </AvatarFallback>
+            </Avatar>
+            <div className="flex flex-col w-full ml-[16px]">
+              <div className="flex items-center gap-[12px]">
+                <p className="text-[14px] text-[#171412]">{post.author.name}</p>
+                <p className="text-sm text-gray-500">{daysAgo}日前</p>
+              </div>
+              <p className="text-gray-800">{post.content}</p>
+              <div className="flex items-center mt-[8px] text-gray-500 gap-[8px]">
+                <ThumbsUp className="w-[20px] h-[20px] text-[14px] text-[#827066]" />
+                <p className="text-[14px] text-[#827066]">{post.likes}</p>
+              </div>
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/components/ui/tabs.tsx
+++ b/components/ui/tabs.tsx
@@ -1,0 +1,66 @@
+"use client"
+
+import * as React from "react"
+import * as TabsPrimitive from "@radix-ui/react-tabs"
+
+import { cn } from "@/lib/utils"
+
+function Tabs({
+  className,
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.Root>) {
+  return (
+    <TabsPrimitive.Root
+      data-slot="tabs"
+      className={cn("ml-[12px] flex flex-col", className)}
+      {...props}
+    />
+  )
+}
+
+function TabsList({
+  className,
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.List>) {
+  return (
+    <TabsPrimitive.List
+      data-slot="tabs-list"
+      className={cn(
+        "flex h-9 w-full items-center gap-[32px] border-b border-b-[1px] border-b-[#e3dede] pl-[16px] pb-[16px] mb-[12px]",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TabsTrigger({
+  className,
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.Trigger>) {
+  return (
+    <TabsPrimitive.Trigger
+      data-slot="tabs-trigger"
+      className={cn(
+        "pt-[16px] pb-[13px] text-[#827066] data-[state=active]:text-[#171412] data-[state=active]:border-b-[3px] data-[state=active]:border-[#e5e8eb] cursor-pointer",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TabsContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.Content>) {
+  return (
+    <TabsPrimitive.Content
+      data-slot="tabs-content"
+      className={cn("flex-1 outline-none", className)}
+      {...props}
+    />
+  )
+}
+
+export { Tabs, TabsList, TabsTrigger, TabsContent }

--- a/package.json
+++ b/package.json
@@ -11,9 +11,10 @@
   },
   "dependencies": {
     "@radix-ui/react-avatar": "^1.1.10",
+    "@radix-ui/react-dialog": "^1.1.14",
     "@radix-ui/react-popover": "^1.1.14",
     "@radix-ui/react-slot": "^1.2.3",
-    "@radix-ui/react-dialog": "^1.1.14",
+    "@radix-ui/react-tabs": "^1.1.12",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.525.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       '@radix-ui/react-slot':
         specifier: ^1.2.3
         version: 1.2.3(@types/react@19.1.8)(react@19.1.0)
+      '@radix-ui/react-tabs':
+        specifier: ^1.1.12
+        version: 1.1.12(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -409,6 +412,19 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-collection@1.1.7':
+    resolution: {integrity: sha512-Fh9rGN0MoI4ZFUNyfFVNU4y9LUz93u9/0K+yLgA2bwRojxM8JU1DyvvMBabnZPBgMWREAJvU2jjVzq+LrFUglw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-compose-refs@1.1.2':
     resolution: {integrity: sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==}
     peerDependencies:
@@ -438,6 +454,15 @@ packages:
       '@types/react':
         optional: true
       '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-direction@1.1.1':
+    resolution: {integrity: sha512-1UEWRX6jnOA2y4H5WczZ44gOOjTEmlqv1uNW4GAJEO5+bauCBhv8snY65Iw5/VOS/ghKN9gr2KjnLKxrsvoMVw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
         optional: true
 
   '@radix-ui/react-dismissable-layer@1.1.10':
@@ -549,6 +574,19 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-roving-focus@1.1.10':
+    resolution: {integrity: sha512-dT9aOXUen9JSsxnMPv/0VqySQf5eDQ6LCk5Sw28kamz8wSOW2bJdlX2Bg5VUIIcV+6XlHpWTIuTPCf/UNIyq8Q==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-slot@1.2.3':
     resolution: {integrity: sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==}
     peerDependencies:
@@ -556,6 +594,19 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
+        optional: true
+
+  '@radix-ui/react-tabs@1.1.12':
+    resolution: {integrity: sha512-GTVAlRVrQrSw3cEARM0nAx73ixrWDPNZAruETn3oHCNP6SbZ/hNxdxp+u7VkIEv3/sFoLq1PfcHrl7Pnp0CDpw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
         optional: true
 
   '@radix-ui/react-use-callback-ref@1.1.1':
@@ -2462,6 +2513,18 @@ snapshots:
       '@types/react': 19.1.8
       '@types/react-dom': 19.1.6(@types/react@19.1.8)
 
+  '@radix-ui/react-collection@1.1.7(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.8)(react@19.1.0)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.1.8)(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.1.8)(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.8
+      '@types/react-dom': 19.1.6(@types/react@19.1.8)
+
   '@radix-ui/react-compose-refs@1.1.2(@types/react@19.1.8)(react@19.1.0)':
     dependencies:
       react: 19.1.0
@@ -2495,6 +2558,12 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.1.8
       '@types/react-dom': 19.1.6(@types/react@19.1.8)
+
+  '@radix-ui/react-direction@1.1.1(@types/react@19.1.8)(react@19.1.0)':
+    dependencies:
+      react: 19.1.0
+    optionalDependencies:
+      '@types/react': 19.1.8
 
   '@radix-ui/react-dismissable-layer@1.1.10(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
@@ -2603,12 +2672,45 @@ snapshots:
       '@types/react': 19.1.8
       '@types/react-dom': 19.1.6(@types/react@19.1.8)
 
+  '@radix-ui/react-roving-focus@1.1.10(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.2
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.8)(react@19.1.0)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.1.8)(react@19.1.0)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.1.8)(react@19.1.0)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.1.8)(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.1.8)(react@19.1.0)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.1.8)(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.8
+      '@types/react-dom': 19.1.6(@types/react@19.1.8)
+
   '@radix-ui/react-slot@1.2.3(@types/react@19.1.8)(react@19.1.0)':
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.8)(react@19.1.0)
       react: 19.1.0
     optionalDependencies:
       '@types/react': 19.1.8
+
+  '@radix-ui/react-tabs@1.1.12(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.2
+      '@radix-ui/react-context': 1.1.2(@types/react@19.1.8)(react@19.1.0)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.1.8)(react@19.1.0)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.1.8)(react@19.1.0)
+      '@radix-ui/react-presence': 1.1.4(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-roving-focus': 1.1.10(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.1.8)(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.8
+      '@types/react-dom': 19.1.6(@types/react@19.1.8)
 
   '@radix-ui/react-use-callback-ref@1.1.1(@types/react@19.1.8)(react@19.1.0)':
     dependencies:


### PR DESCRIPTION
・profile/page.tsxにおいて、Avatar、Button、Tabs（すべてshadcn）をレイアウトし、ページ全体の静的な構造を定義。

・profile/page.tsxの中でも、<Tabs/>{PostList}</Tabs>のような形で、投稿リストの表示に特化したコンポーネントとして切り出す。

・このとき、「投稿」タブが選択されているか「いいね」タブかによって、投稿の表示フォーマットは変わらないが、表示すべきコンテンツは変わるため、PostListにisSelfPostというpropsを渡してタブの状態に関する情報を伝達。

・isSelfPostの値に応じて表示するデータ（自分の投稿をまとめた配列 or 自分がいいねした投稿をまとめた配列）をPostList内部で選択。選択したデータ配列を.map()で展開し、UIを描画。

※PostListコンポーネント内で、投稿ごとの型はPostTypeとして定義

※モックデータもPostListコンポーネント内で定義（PostType型の要素が集合した配列 として方は定義した）