### PR TITLE
Feature: ユーザー管理系API実装

### DIFF
--- a/app/api/me/route.ts
+++ b/app/api/me/route.ts
@@ -1,0 +1,100 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getAuthUser } from "@/lib/auth";
+import { query } from "@/lib/db";
+
+export async function GET(request: NextRequest) {
+  const user = getAuthUser(request);
+  if (!user) {
+    return NextResponse.json({ error: "認証エラー" }, { status: 401 });
+  }
+
+  const result = await query(
+    `SELECT username, user_id, icon_url FROM users WHERE id = $1`,
+    [user.userId]
+  );
+  const profile = result.rows[0];
+
+  if (!profile) {
+    return NextResponse.json(
+      { error: "ユーザーが見つかりません" },
+      { status: 404 }
+    );
+  }
+
+  return NextResponse.json(
+    {
+      username: profile.username,
+      user_id: profile.user_id,
+      icon_url: profile.icon_url,
+    },
+    { status: 200 }
+  );
+}
+
+export async function PUT(request: NextRequest) {
+  const user = getAuthUser(request);
+  if (!user) {
+    return NextResponse.json({ error: "認証エラー" }, { status: 401 });
+  }
+
+  const { username, icon_url, user_id } = await request.json();
+
+  // バリデーション
+  if (username && (typeof username !== "string" || username.length > 50)) {
+    return NextResponse.json(
+      { error: "ユーザーネームは50文字以内で入力してください" },
+      { status: 400 }
+    );
+  }
+  if (icon_url && typeof icon_url !== "string") {
+    return NextResponse.json(
+      { error: "アイコンURLが不正です" },
+      { status: 400 }
+    );
+  }
+  if (user_id && (typeof user_id !== "string" || user_id.length > 20)) {
+    return NextResponse.json(
+      { error: "ユーザーIDは20文字以内で入力してください" },
+      { status: 400 }
+    );
+  }
+
+  // user_id重複チェック
+  if (user_id) {
+    const check = await query(
+      `SELECT id FROM users WHERE user_id = $1 AND id != $2`,
+      [user_id, user.userId]
+    );
+    if (check.rows.length > 0) {
+      return NextResponse.json(
+        { error: "そのユーザーIDは既に登録されています" },
+        { status: 409 }
+      );
+    }
+  }
+
+  await query(
+    `UPDATE users SET 
+      username = COALESCE($1, username), 
+      icon_url = COALESCE($2, icon_url), 
+      user_id = COALESCE($3, user_id) 
+      WHERE id = $4`,
+    [username, icon_url, user_id, user.userId]
+  );
+
+  const result = await query(
+    `SELECT username, user_id, icon_url FROM users WHERE id = $1`,
+    [user.userId]
+  );
+  const profile = result.rows[0];
+
+  return NextResponse.json(
+    {
+      message: "プロフィールを更新しました",
+      username: profile.username,
+      user_id: profile.user_id,
+      icon_url: profile.icon_url,
+    },
+    { status: 200 }
+  );
+}

--- a/app/api/users/[id]/likes/route.ts
+++ b/app/api/users/[id]/likes/route.ts
@@ -1,0 +1,51 @@
+import { NextRequest, NextResponse } from "next/server";
+import { query } from "@/lib/db";
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  const userId = params.id;
+
+  const result = await query(
+    `
+    SELECT 
+      p.id,
+      p.content,
+      p.created_at,
+      u.username,
+      u.user_id,
+      u.icon_url,
+      COUNT(l2.id) as like_count
+    FROM likes l
+    JOIN posts p ON l.post_id = p.id
+    JOIN users u ON p.user_id = u.id
+    LEFT JOIN likes l2 ON p.id = l2.post_id
+    WHERE l.user_id = (SELECT id FROM users WHERE user_id = $1)
+    GROUP BY p.id, u.id, u.username, u.user_id, u.icon_url
+    ORDER BY p.created_at DESC
+    LIMIT 50
+    `,
+    [userId]
+  );
+
+  const posts = result.rows.map((row) => ({
+    id: row.id,
+    content: row.content,
+    created_at: row.created_at,
+    user: {
+      username: row.username,
+      user_id: row.user_id,
+      icon_url: row.icon_url,
+    },
+    like_count: parseInt(row.like_count) || 0,
+  }));
+
+  return NextResponse.json(
+    {
+      posts,
+      count: posts.length,
+    },
+    { status: 200 }
+  );
+}

--- a/app/api/users/[id]/likes/route.ts
+++ b/app/api/users/[id]/likes/route.ts
@@ -3,9 +3,9 @@ import { query } from "@/lib/db";
 
 export async function GET(
   request: NextRequest,
-  { params }: { params: { id: string } }
+  props: { params: Promise<{ id: string }> }
 ) {
-  const userId = params.id;
+  const { id: userId } = await props.params;
 
   const result = await query(
     `

--- a/app/api/users/[id]/posts/route.ts
+++ b/app/api/users/[id]/posts/route.ts
@@ -3,9 +3,9 @@ import { query } from "@/lib/db";
 
 export async function GET(
   request: NextRequest,
-  { params }: { params: { id: string } }
+  props: { params: Promise<{ id: string }> }
 ) {
-  const userId = params.id;
+  const { id: userId } = await props.params;
 
   const result = await query(
     `

--- a/app/api/users/[id]/posts/route.ts
+++ b/app/api/users/[id]/posts/route.ts
@@ -1,0 +1,50 @@
+import { NextRequest, NextResponse } from "next/server";
+import { query } from "@/lib/db";
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  const userId = params.id;
+
+  const result = await query(
+    `
+    SELECT 
+      p.id,
+      p.content,
+      p.created_at,
+      u.username,
+      u.user_id,
+      u.icon_url,
+      COUNT(l.id) as like_count
+    FROM posts p
+    JOIN users u ON p.user_id = u.id
+    LEFT JOIN likes l ON p.id = l.post_id
+    WHERE u.user_id = $1
+    GROUP BY p.id, u.id, u.username, u.user_id, u.icon_url
+    ORDER BY p.created_at DESC
+    LIMIT 50
+    `,
+    [userId]
+  );
+
+  const posts = result.rows.map((row) => ({
+    id: row.id,
+    content: row.content,
+    created_at: row.created_at,
+    user: {
+      username: row.username,
+      user_id: row.user_id,
+      icon_url: row.icon_url,
+    },
+    like_count: parseInt(row.like_count) || 0,
+  }));
+
+  return NextResponse.json(
+    {
+      posts,
+      count: posts.length,
+    },
+    { status: 200 }
+  );
+}

--- a/app/api/users/[id]/route.ts
+++ b/app/api/users/[id]/route.ts
@@ -3,9 +3,9 @@ import { query } from "@/lib/db";
 
 export async function GET(
   request: NextRequest,
-  { params }: { params: { id: string } }
+  props: { params: Promise<{ id: string }> }
 ) {
-  const userId = params.id;
+  const { id: userId } = await props.params;
 
   const result = await query(
     `SELECT username, user_id, icon_url FROM users WHERE user_id = $1`,

--- a/app/api/users/[id]/route.ts
+++ b/app/api/users/[id]/route.ts
@@ -1,0 +1,31 @@
+import { NextRequest, NextResponse } from "next/server";
+import { query } from "@/lib/db";
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  const userId = params.id;
+
+  const result = await query(
+    `SELECT username, user_id, icon_url FROM users WHERE user_id = $1`,
+    [userId]
+  );
+  const profile = result.rows[0];
+
+  if (!profile) {
+    return NextResponse.json(
+      { error: "ユーザーが見つかりません" },
+      { status: 404 }
+    );
+  }
+
+  return NextResponse.json(
+    {
+      username: profile.username,
+      user_id: profile.user_id,
+      icon_url: profile.icon_url,
+    },
+    { status: 200 }
+  );
+}

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -14,6 +14,8 @@ tags:
     description: 認証・ユーザー登録
   - name: Posts
     description: 投稿
+  - name: Users
+    description: ユーザー管理
 
 paths:
   /api/auth/register:
@@ -176,6 +178,181 @@ paths:
           description: サーバーエラー
       security:
         - cookieAuth: []
+
+  /api/me:
+    get:
+      tags: [Users]
+      summary: 自分のプロフィール取得
+      responses:
+        "200":
+          description: プロフィール情報
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  username: { type: string }
+                  user_id: { type: string }
+                  icon_url: { type: string }
+        "401":
+          description: 認証エラー
+        "404":
+          description: ユーザーが見つからない
+        "500":
+          description: サーバーエラー
+      security:
+        - cookieAuth: []
+
+    put:
+      tags: [Users]
+      summary: 自分のプロフィール更新
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                username:
+                  type: string
+                  maxLength: 50
+                  description: 新しいユーザーネーム
+                icon_url:
+                  type: string
+                  description: 新しいアイコン画像URL
+                user_id:
+                  type: string
+                  maxLength: 20
+                  description: 新しいユーザーID（重複不可）
+      responses:
+        "200":
+          description: プロフィール更新成功
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message: { type: string }
+                  username: { type: string }
+                  user_id: { type: string }
+                  icon_url: { type: string }
+        "400":
+          description: バリデーションエラー
+        "401":
+          description: 認証エラー
+        "409":
+          description: ユーザーID重複
+        "500":
+          description: サーバーエラー
+      security:
+        - cookieAuth: []
+
+  /api/users/{id}:
+    get:
+      tags: [Users]
+      summary: 他ユーザーのプロフィール取得
+      parameters:
+        - name: id
+          in: path
+          required: true #なんかエラー出るけど直せないので無視
+          schema:
+            type: string
+          description: ユーザーID
+      responses:
+        "200":
+          description: プロフィール情報
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  username: { type: string }
+                  user_id: { type: string }
+                  icon_url: { type: string }
+        "404":
+          description: ユーザーが見つからない
+        "500":
+          description: サーバーエラー
+
+  /api/users/{id}/posts:
+    get:
+      tags: [Users]
+      summary: ユーザーの投稿一覧取得
+      parameters:
+        - name: id
+          in: path
+          required: true #なんかエラー出るけど直せないので無視
+          schema:
+            type: string
+          description: ユーザーID
+      responses:
+        "200":
+          description: 投稿一覧
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  posts:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id: { type: string }
+                        content: { type: string }
+                        created_at: { type: string, format: date-time }
+                        user:
+                          type: object
+                          properties:
+                            username: { type: string }
+                            user_id: { type: string }
+                            icon_url: { type: string }
+                        like_count: { type: integer }
+                  count: { type: integer }
+        "404":
+          description: ユーザーが見つからない
+        "500":
+          description: サーバーエラー
+
+  /api/users/{id}/likes:
+    get:
+      tags: [Users]
+      summary: ユーザーがいいねした投稿一覧取得
+      parameters:
+        - name: id
+          in: path
+          required: true #なんかエラー出るけど直せないので無視
+          schema:
+            type: string
+          description: ユーザーID
+      responses:
+        "200":
+          description: いいねした投稿一覧
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  posts:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id: { type: string }
+                        content: { type: string }
+                        created_at: { type: string, format: date-time }
+                        user:
+                          type: object
+                          properties:
+                            username: { type: string }
+                            user_id: { type: string }
+                            icon_url: { type: string }
+                        like_count: { type: integer }
+                  count: { type: integer }
+        "404":
+          description: ユーザーが見つからない
+        "500":
+          description: サーバーエラー
 
 components:
   securitySchemes:


### PR DESCRIPTION
## 具体的にしたこと

- ユーザー管理APIの実装
  - GET /api/me: 自分のプロフィール取得
  - PUT /api/me: 自分のプロフィール更新（ユーザーID重複チェック含む）
  - GET /api/users/[id]: 他ユーザーのプロフィール取得
  - GET /api/users/[id]/posts: 特定ユーザーの投稿一覧取得
  - GET /api/users/[id]/likes: 特定ユーザーがいいねした投稿一覧取得
- 取得・返却するプロフィール情報や投稿情報は既存APIの仕様に準拠
- openapi.yamlに上記API仕様を追記・整理

## どうこの変更を読めばいいか

- 各APIのroute.tsを参照すると、データ取得・レスポンス構造が分かります
- openapi.yamlでエンドポイント仕様やリクエスト/レスポンス形式を確認できます
- PUT /api/meはuser_id更新時に重複チェックを行い、既存IDの場合は409エラーを返します

## その他
動作確認していないので、動作確認してほしいです。
動作確認の手段は問わない。ソフトウェア使っても、CLIから直接curl叩いても。APIからちゃんとレスポンスが帰ってきたらok。